### PR TITLE
Fixed a security issue with handling directory and file names

### DIFF
--- a/check-sugid.script
+++ b/check-sugid.script
@@ -40,18 +40,22 @@ fi
 trap 'rc=$?; trap - EXIT; rm -f -- $TMPFILE; exit $rc' EXIT HUP INT QUIT ABRT KILL SEGV TERM
 
 # Determine the locally mounted filesystems
-sed -n '/^[[:space:]]*nodev[[:space:]]/!{s/^[[:space:]]\+/^/;s/[[:space:]]*$/\\s/};T;p' /proc/filesystems > "$TMPFILE" ||:
-FS_LIST=$(sed -n 's/^\([[:space:]]*[^[:space:]]\+\)[[:space:]]\([^[:space:]]\+\)[[:space:]]\([^[:space:]]\+\).*/\3 \2/;T;p' /proc/mounts | grep -f "$TMPFILE" | cut -f2 -d ' ') ||:
-FS_LIST="${FS_LIST:-/}"
+if [ -z "${FS_LIST:-}" ]; then
+	sed -n '/^[[:space:]]*nodev[[:space:]]/!{s/^[[:space:]]\+/^/;s/[[:space:]]*$/\\s/};T;p' /proc/filesystems > "$TMPFILE" ||:
+	FS_LIST=$(sed -n 's/^\([[:space:]]*[^[:space:]]\+\)[[:space:]]\([^[:space:]]\+\)[[:space:]]\([^[:space:]]\+\).*/\3 \2/;T;p' /proc/mounts | grep -f "$TMPFILE" | cut -f2 -d ' ') ||:
+	FS_LIST="${FS_LIST:-/}"
+fi
 
 > "$TMPFILE"
 test -s /etc/yum/post-actions/check-sugid.action && \
 	grep -E '^#?/.*:(install|update):' /etc/yum/post-actions/check-sugid.action \
 		| grep setcap | cut -f1 -d: | cut -f2 -d'#' | LC_ALL=C sort | uniq > "$TMPFILE" ||:
 
-CAP_LIST=$(find $FS_LIST -xdev -xautofs -type f -perm /0111 -print0 \
+CAP_LIST=$(find $FS_LIST -xdev -type f -perm /0111 -print0 \
 		| grep -zZ -F -v -f "$TMPFILE" \
-		| xargs -0 -i /bin/sh -c 'CAP=$(getcap "{}"); [ "$CAP" != "${CAP/=}" ] && stat "--printf=# UNK: %A/%a %U/%G (${CAP##* = }) %n\n" "{}"' \
+		| xargs -0 -i /bin/sh -c 'CAP=$(getcap '"'{}'"'); [ "$CAP" != "${CAP/=}" ] \
+				&& stat "--printf=# UNK: %A/%a %U/%G (${CAP##* = }) %n\0" '"'{}'" \
+                | sed -z '/^[[:space:]]*$/d;s/\n/\\n/g;s/$/\n/' | tr -d '\0' \
 		||: \
 )
 
@@ -59,9 +63,13 @@ CAP_LIST=$(find $FS_LIST -xdev -xautofs -type f -perm /0111 -print0 \
 test -s /etc/yum/post-actions/check-sugid.action && \
 	grep -E '^#/.*:(install|update):' /etc/yum/post-actions/check-sugid.action \
 		| cut -f1 -d: | cut -f2 -d'#' | LC_ALL=C sort | uniq > "$TMPFILE" ||:
-printf "$CAP_LIST\n" | cut -f6- -d' ' | LC_ALL=C sort | uniq >> "$TMPFILE" ||:
-LIST=$(find $FS_LIST -xdev -xautofs -type f -perm /6000 -printf "# UNK: %M/%m %u/%g () %p\n" 2>/dev/null | LC_ALL=C sort -k6 -t' ' | grep -F -v -f "$TMPFILE" ||:)
-LIST=$(printf "$CAP_LIST\n$LIST\n" | LC_ALL=C sort -k6 -t' ')
+printf '%s\n' "$CAP_LIST" | cut -f6- -d' ' | LC_ALL=C sort | uniq >> "$TMPFILE" ||:
+LIST=$(find $FS_LIST -xdev -type f -perm /6000 -printf "# UNK: %M/%m %u/%g () %p\0" 2>/dev/null \
+		| sed -z '/^[[:space:]]*$/d;s/\n/\\n/g;s/$/\n/' | tr -d '\0' \
+		| LC_ALL=C sort -k6 -t' ' | grep -F -v -f "$TMPFILE" \
+		||: \
+)
+LIST=$(printf '%s\n%s\n' "$CAP_LIST" "$LIST" | LC_ALL=C sort -k6 -t' ')
 
 if [ -n "$LIST" ]; then
 	cat <<-__EOF__
@@ -84,15 +92,19 @@ if [ -n "$LIST" ]; then
 		==============================================================================
 
 __EOF__
-	printf "$LIST\n" | \
-		while read LINE; do
+	printf '%s\n' "$LIST" | \
+		while read -r LINE; do
 			[ -z "$LINE" ] && continue || :
-			FILENAME=$(printf "$LINE" | cut -f6- -d' ')
-			HEADER="${LINE% $FILENAME}"
-			CAPS=$(printf "$HEADER" | cut -f5 -d' ' | sed 's,^(,,;s,[[:space:]]*)$,,')
+			FILENAME=$(printf '%s' "$LINE" | cut -f6- -d' ')
+			HEADER=$(printf '%s' "$LINE" | cut -f-5 -d' ')
+			CAPS=$(printf '%s' "$HEADER" | cut -f5 -d' ' | sed 's,^(,,;s,[[:space:]]*)$,,')
 			[ -z "$CAPS" ] && HEADER="${HEADER% ()}" ||:
-			PERMS=$(printf "$HEADER" | cut -f2 -d/ | cut -f1 -d' ')
-			printf "$HEADER\n#$FILENAME:install:chmod $PERMS \"$FILENAME\"${CAPS:+ && setcap $CAPS \"$FILENAME\"}\n#$FILENAME:update:chmod $PERMS \"$FILENAME\"${CAPS:+ && setcap $CAPS \"$FILENAME\"}\n\n"
+			PERMS=$(printf '%s' "$HEADER" | cut -f2 -d/ | cut -f1 -d' ')
+			printf '%s\n#%s:install:chmod %d '"'%s'" "$HEADER" "$FILENAME" "$PERMS" "${FILENAME//\\n/\'\$\'\\n\'\'}"
+			[ -n "${CAPS:-}" ] && printf '; setcap "%s" '"'%s'" "$CAPS" "${FILENAME//\\n/\'\$\'\\n\'\'}" ||:
+			printf '\n#%s:update:chmod %d '"'%s'" "$FILENAME" "$PERMS" "${FILENAME//\\n/\'\$\'\\n\'\'}"
+			[ -n "${CAPS:-}" ] && printf '; setcap "%s" '"'%s'" "$CAPS" "${FILENAME//\\n/\'\$\'\\n\'\'}" ||:
+			printf '\n\n'
 		    done
 	  exit 1
 fi

--- a/check-sugid.spec
+++ b/check-sugid.spec
@@ -1,5 +1,5 @@
 Name:		check-sugid
-Version:	0.0.1
+Version:	0.0.2
 Release:	1
 License:	GPLv3+
 Group:		System Environment/Base/Security
@@ -33,5 +33,8 @@ install -m700 -p '%_sourcedir/%name.script' '%buildroot%_sbindir/%name'
 %attr(0700,root,root) %_sbindir/%name
 
 %changelog
+* Tue Jul 23 2019 (GalaxyMaster) <galaxy-at-openwall.com> - 0.0.2-1
+- SECURITY: introduced proper handling of weird file and directory names.
+
 * Sun Apr 03 2016 (GalaxyMaster) <galaxy-at-openwall.com> - 0.0.1-1
 - Initial release to the public.


### PR DESCRIPTION
- Fixes issue #1: it was discovered that the names that contain a
  dollar sign were subject for variable expansion and the names
  which had embedded newlines were breaking the script.
- introduced a possibility to select which tree is scanned by
  respecting the FS_LIST environment variable
- removed the "-xauto" parameter from the "find" command-line
  since it is non-standard parameter.